### PR TITLE
Various enhancements

### DIFF
--- a/Code/platformio.ini
+++ b/Code/platformio.ini
@@ -1,7 +1,20 @@
+[platformio]
+description = tpms_silencer
+default_envs = attiny841
+
 [env:attiny841]
 platform = atmelavr
 board = attiny841
 framework = arduino
+
+# its possible the internal clk is accurate enough but use external xtal for now.
 board_fuses.lfuse = 0xEE
 board_fuses.efuse = 0xFE
 board_fuses.hfuse = 0xD6
+# -B0.5 will speed up the baud-rate.
+# If you have problems flashing, remove these flags m
+upload_flags =
+    -B0.5
+
+# required before programming is possible:
+# ./avrdude.exe -c usbtiny -p attiny841 -U hfuse:w:0xd6:m  -U efuse:w:0xfe:m  -U lfuse:w:0xee:m 

--- a/Code/src/main.cpp
+++ b/Code/src/main.cpp
@@ -4,21 +4,30 @@
 #include <Arduino.h>
 #include "tpms_silencer.h"
 
-#define PIN_EN A0  // PA0, Pin 13, Arduino 10
-#define PIN_FSK A1 // PA1, Pin 12, Arduino 9
-#define PIN_ASK A2 // PA2, Pin 11, Arduino 8
-#define PIN_BUTTON A7 // PA7, Pin 6, PCINT7
-#define INTERRUPT_PIN PCINT7
+/*
+Each bit/symbol: 0/1 is 100us long. sent at a rate of 10kHz
+144 symbols sent = 14.4ms long packets (+ 300us warmup)
+Packets are sent 40ms apart, then we sleep.
+If PERIODIC_TX is defined then wakeup after 7s * wakeuplimit (which is potentially variable)
+BACKOFF will double the retransmit period each time until MAX_LIMIT.
+*/
 
-#define ENABLE_WDT // disable for tx on button press only
-#define BACKOFF // double transmit period everytime
+#define PIN_EN     A0  // PA0, Pin 13, Arduino 10
+#define PIN_FSK    A1 // PA1, Pin 12, Arduino 9
+#define PIN_ASK    A2 // PA2, Pin 11, Arduino 8
+#define PIN_BUTTON A7 // PA7, Pin 6, PCINT7
+#define INTERRUPT_PIN PCINT7 // interrupt for PA7
+
+#define PERIODIC_TX // periodic retransmissions. disable for button-press tx only
+//#define BACKOFF    // double transmit period everytime? disable to have a fixed period retrans.
 
 #define ENHIGH (bitSet(PORTA, 0))
 #define ENLOW (bitClear(PORTA, 0))
 
+// * unecessary hardware modification *
 // Tie ASK and FSK signals together to drive high stronger/faster?
 // cut ASK link between attiny and MICRF112.
-// bodge ASK to EN on MICRF112. and ASK/FSK together on the attiny
+// bodge ASK to EN on MICRF112. and ASK/FSK together on the attiny.
 //#define FSK_MOD
 
 #ifdef FSK_MOD
@@ -26,10 +35,10 @@
 #define ASKHIGH {}
 #define ASKLOW {}
 
-// reversed for some reason
-#define FSKHIGH (PORTA &= ~(0x6))
-#define FSKLOW (PORTA |= 0x6)
-#define FSKTOGGLE (PORTA = PORTA ^ _BV(0x6))
+// drive PA1 & PA2 together
+#define FSKLOW (PORTA &= ~(0x6))
+#define FSKHIGH (PORTA |= 0x6)
+#define FSKTOGGLE (PORTA = PORTA ^ (0x6))
 
 #else
 
@@ -42,21 +51,18 @@
 
 #endif
 
-#define PACKETSIZE 144
-
-#define PACKET_DELAY 65 // Milliseconds period for packet tx
+#define PACKET_DELAY   40 // Milliseconds inter-packet period
 #ifdef BACKOFF
-#define LIMIT_START   1 // (re-transmit intervals: 14s, 28s, 56s, ..., MAX_LIMIT/8)
-#define MAX_LIMIT     160 // 80 max limit = 10mins
+#define LIMIT_START     1 // (re-transmit intervals: 14s, 28s, 56s, ..., MAX_LIMIT/8)
+//#define MAX_LIMIT      80 // 80 max limit = 10mins.  
+#define MAX_LIMIT     160 // 160 max limit = 20 mins.
 #else
-#define LIMIT_START   8 // ~60s = 8*(7s) wakeups before transmit
+//#define LIMIT_START     8 // ~60s period = 8*(7s) wakeups before transmit
+#define LIMIT_START     120 // ~15mins period = 120*(7s) wakeups before transmit
 #endif
 
 /*
-Each symbol 0/1 is 100us long. sent at a rate of 10kHz
-144 symbols sent = 14.4ms long packets (+ 300us warmup)
-Each packet sent 65ms appart
-
+captured tpms data: with rtl_433 -vv ...
 time      : 2021-10-22 18:46:04
 model     : PMV-107J     type      : TPMS          id        : 07698722
 status    : 16           battery_ok: 1             counter   : 2             failed    : OK            pressure_kPa: 228.160     temperature_C: 13.000     mic       : CRC
@@ -77,11 +83,6 @@ status    : 16           battery_ok: 1             counter   : 2             fai
 pulse_demod_pcm(): PMV-107J (Toyota) TPMS
 bitbuffer:: Number of rows: 1 
 [00] {144} fc cc b4 ac b2 b3 55 52 b5 52 aa ab 33 35 34 b3 53 2c 
-13C = 53 = 0x35 = 0 0 1 1 0 1 0 1
-1111110 01100110010110100101011001011001010110011010101010101001010110101010100101010101010101011001100110011010100110100101100110101001100101100
-        0 0 0 0 0 1 0 1 0 1 1 0 0 1 0 0 1 1 0 0 0 1 1 1 1 1 1 0 1 1 0 1 1 1 1 0 1 1 1 1 1 1 1 1 1 0 0 0 0 0 0 1 1 0 0 1 0 1 0 0 0 1 1 0 0 0 1 0 0
-                 |       |       |       |       |       |       |       |       |       |       |       |       |       |       |       |       |
-                0       a       c       4       c       7       e       d       e       f       f       8       1       9       4       6        
 _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
 time      : 2021-10-22 18:46:14
 model     : PMV-107J     type      : TPMS          id        : 00a89722
@@ -89,31 +90,36 @@ status    : 8            battery_ok: 1             counter   : 1             fai
 pulse_demod_pcm(): PMV-107J (Toyota) TPMS
 bitbuffer:: Number of rows: 1 
 [00] {144} fc aa d2 d5 2b 4c ad 52 ad 52 ab 4b 32 d5 34 d5 2b 2c
-*/
-/* check diff manchester:
-apparently:
-          FC CD 55 55 4A B4 D4 B2 AD 52 AB 54 CD 34 AB 54 CD 2C
-"1 111110 01 10 011010101010101010101010 0101010110100110101001011001010101101010100101010101101010100110011010011010010101011010101001100110100101100";
-          0  0  0 0 1 1 1 1 1 1 1 1 1 1  0 1 1 1 0 1 0 0 1 1 0 1 0 0 1 1 1 0 1 1 1 0 1 1 1 1 0 1 1 1 0 0 0 0 1 0 0 1 0 1 1 1 0 1 1 1 0 0 0 0 1 0 1 0 0
 
 */
 
 
 // use the compact encoding reported by rtl_433 -vv  <-f 315M -R 110> 
-// Could also store the Diff Manchester decoded values.
-// Or generate whole packets on the fly!
-const unsigned char packets[4][18] = { { 0xfc, 0xb3, 0x4d, 0x2b, 0x2a, 0xb3, 0x52, 0xad, 0x4a, 0xad, 0x54, 0xab, 0x32, 0xca, 0xcb, 0x4d, 0x2c, 0xac},
-                              { 0xfc, 0xd5, 0x55, 0x4b, 0x2d, 0x4c, 0xad, 0x52, 0xb2, 0xad, 0x55, 0x4b, 0x33, 0x2a, 0xcb, 0x4c, 0xcd, 0x4c},
-                              { 0xfc, 0xcc, 0xb4, 0xac, 0xb2, 0xb3, 0x55, 0x52, 0xb5, 0x52, 0xaa, 0xab, 0x33, 0x35, 0x34, 0xb3, 0x53, 0x2c},
-                              { 0xfc, 0xaa, 0xd2, 0xd5, 0x2b, 0x4c, 0xad, 0x52, 0xad, 0x52, 0xab, 0x4b, 0x32, 0xd5, 0x34, 0xd5, 0x2b, 0x2c} };
-volatile unsigned char packet=0;
-volatile unsigned int currentBit;
+// Could also store the Differential-Manchester decoded values...
+// Or generate whole packets on the fly.
+#define NO_PACKETS      4
+#define PACKET_LEN     18
+#define PACKETSIZE    (PACKET_LEN*8) // 144 bits
+const unsigned char packets[NO_PACKETS][PACKET_LEN] = { 
+  // packet 0
+  { 0xfc, 0xb3, 0x4d, 0x2b, 0x2a, 0xb3, 0x52, 0xad, 0x4a, 0xad, 0x54, 0xab, 0x32, 0xca, 0xcb, 0x4d, 0x2c, 0xac},
+  // packet 1
+  { 0xfc, 0xd5, 0x55, 0x4b, 0x2d, 0x4c, 0xad, 0x52, 0xb2, 0xad, 0x55, 0x4b, 0x33, 0x2a, 0xcb, 0x4c, 0xcd, 0x4c},
+  // packet 2
+  { 0xfc, 0xcc, 0xb4, 0xac, 0xb2, 0xb3, 0x55, 0x52, 0xb5, 0x52, 0xaa, 0xab, 0x33, 0x35, 0x34, 0xb3, 0x53, 0x2c},
+  // packet 3
+  { 0xfc, 0xaa, 0xd2, 0xd5, 0x2b, 0x4c, 0xad, 0x52, 0xad, 0x52, 0xab, 0x4b, 0x32, 0xd5, 0x34, 0xd5, 0x2b, 0x2c} };
 
-volatile bool transmitting = false;
+volatile unsigned char packet=0; // which packet is being sent 0 - NO_PACKETS-1
+volatile unsigned int currentBit; // which bit in that packet is next
 
-volatile unsigned int wakeupCounter = 0;
-volatile unsigned int wakeuplimit = LIMIT_START;  // How many 8-second wakeups before transmit
+volatile bool transmitting = false; // indicates if transmitting
 
+volatile unsigned int wakeupCounter = 0; // how many 8s watchdog timeouts since last transmit
+volatile unsigned int wakeuplimit = LIMIT_START;  // How many 8-second wakeups before transmit again
+
+
+// setup functions
 
 // 10khz Interrupt for an 8MHz clock
 void setupInterrupt8()
@@ -174,6 +180,7 @@ void setup()
   ADCSRA = 0;
   power_spi_disable();
   power_usart0_disable();
+  power_usart1_disable(); //probably ok
   power_timer2_disable();
   power_twi_disable();
 
@@ -182,7 +189,7 @@ void setup()
   pinMode(PIN_ASK, OUTPUT);
   pinMode(PIN_BUTTON, INPUT_PULLUP);
   
-#ifdef ENABLE_WDT
+#ifdef PERIODIC_TX
   /* Clear the reset flags. */
   MCUSR = 0;
 
@@ -203,6 +210,8 @@ void setup()
   wakeupCounter = wakeuplimit; // force an immediate transmit
 }
 
+// runtime functions
+
 // 100 usec timer for bit tx
 ISR(TIMER1_COMPA_vect)
 {
@@ -215,19 +224,20 @@ ISR(TIMER1_COMPA_vect)
     }
 
     // read off bits in bigendian order
-    if ( ( packets[packet][currentBit/8] & (0x80>>(currentBit % 8)) ) ) 
-      FSKHIGH;
+    if ( ( packets[packet][currentBit/8] & ( 0x80 >> (currentBit % 8) ) ) )
+      FSKLOW; // low signal - higher freq
     else
-      FSKLOW;
+      FSKHIGH; // high signal - lower freq
+    
     currentBit++;
   }
 }
 
-#ifdef ENABLE_WDT
+#ifdef PERIODIC_TX
 // watchdog timer is setup by setupInterrupt8(). roughly 7-8s at 3v.
 ISR(WDT_vect)
 {
-  // ensure next watchdog uses the interrupt too
+  // reset WDIE to ensure next watchdog uses the interrupt too (dont reboot!)
   WDTCSR |= bit(WDIE);
   wakeupCounter++;
 }
@@ -237,7 +247,7 @@ ISR(WDT_vect)
 ISR(PCINT0_vect)
 {
   if( digitalRead(PIN_BUTTON) == LOW ) {
-    // button press. force wakeup and initial retransmit period
+    // button press. wakeup, transmit and set initial retransmit period
     wakeuplimit = LIMIT_START;
     wakeupCounter = wakeuplimit;
   //} else {
@@ -245,6 +255,7 @@ ISR(PCINT0_vect)
   }
 }
 
+// sleep until an WDT/button interrupt fires
 void sleepyTime()
 {
   // Just in case
@@ -257,40 +268,17 @@ void sleepyTime()
   sleep_disable();
 }
 
+// queue up and prepare to send a packet
 void sendPacket(unsigned int which)
 {
   transmitting = false; // just in case...
-  packet = which;
+  packet = min( which, NO_PACKETS-1 );
   currentBit = 0;
 
   enableTX();
 }
 
-void loop()
-{
-  if (wakeupCounter >= wakeuplimit)
-  {
-    for (int i=0;i<4;i++) {
-      sendPacket(i);
-      delay(PACKET_DELAY);
-    }
-
-    // reset to wait for next tx
-    wakeupCounter = 0;
-
-#ifdef BACKOFF
-    // double the wakeuplimit each time to back-off and save battery
-    wakeuplimit *= 2;
-#ifdef MAX_LIMIT
-    // up to this limit
-    wakeuplimit = min(wakeuplimit, MAX_LIMIT);
-#endif
-#endif
-  }
-
-  sleepyTime();
-}
-
+// warm-up transmitter and enable bit-period interrupt
 void enableTX()
 {
   FSKLOW;
@@ -302,10 +290,36 @@ void enableTX()
   power_timer1_enable();
 }
 
+// disable transmitter and disable bit-period interrupt
 void disableTX()
 {
   ENLOW;
   FSKLOW;
   transmitting = false;
   power_timer1_disable();
+}
+
+void loop()
+{
+  if (wakeupCounter >= wakeuplimit)
+  {
+    for (int i=0; i<NO_PACKETS; i++) {
+      sendPacket(i);
+      delay(PACKET_DELAY);
+    }
+
+    // reset to wait for next tx
+    wakeupCounter = 0;
+
+#ifdef BACKOFF
+    // double the wakeuplimit each time to back-off and save battery
+    wakeuplimit *= 2;
+#ifdef MAX_LIMIT
+    // but only up to this limit:
+    wakeuplimit = min(wakeuplimit, MAX_LIMIT);
+#endif
+#endif
+  }
+
+  sleepyTime();
 }

--- a/Code/src/main.cpp
+++ b/Code/src/main.cpp
@@ -11,29 +11,124 @@
 #define PIN_EN A0  // PA0, Pin 13, Arduino 10
 #define PIN_FSK A1 // PA1, Pin 12, Arduino 9
 #define PIN_ASK A2 // PA2, Pin 11, Arduino 8
+#define PIN_BUTTON A7 // PA7, Pin 6, PCINT7
+#define INTERRUPT_PIN PCINT7
 
-#define FSKLOW (bitSet(PORTA, 1))
-#define FSKHIGH (bitClear(PORTA, 1))
+// Tie ASK and FSK signals together to drive high stronger/faster?
+// cut ASK link between attiny and MICRF112.
+// bodge ASK to EN on MICRF112. and ASK/FSK together on the attiny
+#define FSK_MOD
+
+#define ENHIGH (bitSet(PORTA, 0))
+#define ENLOW (bitClear(PORTA, 0))
+
+#ifdef FSK_MOD
+#define ASKHIGH {}
+#define ASKLOW {}
+
+// reversed for some reason
+#define FSKHIGH (PORTA &= ~(0x6))
+#define FSKLOW (PORTA |= 0x6)
+#define FSKTOGGLE (PORTA = PORTA ^ _BV(0x6))
+
+#else
+
+#define ASKHIGH (bitSet(PORTA, 2))
+#define ASKLOW (bitClear(PORTA, 2))
+
+#define FSKHIGH (bitSet(PORTA, 1))
+#define FSKLOW (bitClear(PORTA, 1))
 #define FSKTOGGLE (PORTA = PORTA ^ _BV(1))
+
+#endif
 
 #define PACKETSIZE 144
 
-#define PACKET_DELAY 25 // Milliseconds between packets
-#define WAKEUPCOUNT 16  // How make 8-second wakeups before transmit
+#define PACKET_DELAY 50 // Milliseconds period for packet tx
+#define WAKEUPCOUNT 1  // How many 8-second wakeups before transmit
 
-const char PROGMEM packetOne[] = "111111001100110101010101010101010100101010110100110101001011001010101101010100101010101101010100110011010011010010101011010101001100110100101100";
-const char PROGMEM packetTwo[] = "111111001011001100101011001100101010101101001011001011010101010101001010101011010101010100110100110011001010101101010101001100101010101010101100";
-const char PROGMEM packetFour[] = "111111001100110010101010101011010010101010110100110101001011001101010010101011010101010101010100110011001100101101010101010011001100110101001100";
-const char PROGMEM packetThree[] = "111111001011001010110011010010101100110101001011001010110100101101001101010100101010101011010100110011001011010010101011010101001101010010101100";
+/*
+Each symbol 0/1 is 100us long. sent at a rate of 10kHz
+144 symbols sent = 14.4ms long packets
+Each packet sent 40.85/40.9ms appart
+Notes. currently retransmits every 2:26s (when wakeupCounter > 16)
+
+time      : 2021-10-22 18:46:04
+model     : PMV-107J     type      : TPMS          id        : 07698722
+status    : 16           battery_ok: 1             counter   : 2             failed    : OK            pressure_kPa: 228.160     temperature_C: 13.000     mic       : CRC
+pulse_demod_pcm(): PMV-107J (Toyota) TPMS
+bitbuffer:: Number of rows: 1 
+[00] {143} fc b3 4d 2b 2a b3 52 ad 4a ad 54 ab 32 ca cb 4d 2c ac 
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
+time      : 2021-10-22 18:46:13
+model     : PMV-107J     type      : TPMS          id        : 0805a722
+status    : 24           battery_ok: 1             counter   : 3             failed    : OK            pressure_kPa: 220.720     temperature_C: 13.000     mic       : CRC
+pulse_demod_pcm(): PMV-107J (Toyota) TPMS
+bitbuffer:: Number of rows: 1 
+[00] {143} fc d5 55 4b 2d 4c ad 52 b2 ad 55 4b 33 2a cb 4c cd 4c 
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
+time      : 2021-10-22 18:46:14
+model     : PMV-107J     type      : TPMS          id        : 0f536702
+status    : 16           battery_ok: 1             counter   : 2             failed    : OK            pressure_kPa: 218.240     temperature_C: 13.000     mic       : CRC
+pulse_demod_pcm(): PMV-107J (Toyota) TPMS
+bitbuffer:: Number of rows: 1 
+[00] {144} fc cc b4 ac b2 b3 55 52 b5 52 aa ab 33 35 34 b3 53 2c 
+13C = 53 = 0x35 = 0 0 1 1 0 1 0 1
+1111110 01100110010110100101011001011001010110011010101010101001010110101010100101010101010101011001100110011010100110100101100110101001100101100
+        0 0 0 0 0 1 0 1 0 1 1 0 0 1 0 0 1 1 0 0 0 1 1 1 1 1 1 0 1 1 0 1 1 1 1 0 1 1 1 1 1 1 1 1 1 0 0 0 0 0 0 1 1 0 0 1 0 1 0 0 0 1 1 0 0 0 1 0 0
+                 |       |       |       |       |       |       |       |       |       |       |       |       |       |       |       |       |
+                0       a       c       4       c       7       e       d       e       f       f       8       1       9       4       6        
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
+time      : 2021-10-22 18:46:14
+model     : PMV-107J     type      : TPMS          id        : 00a89722
+status    : 8            battery_ok: 1             counter   : 1             failed    : OK            pressure_kPa: 230.640     temperature_C: 14.000     mic       : CRC
+pulse_demod_pcm(): PMV-107J (Toyota) TPMS
+bitbuffer:: Number of rows: 1 
+[00] {144} fc aa d2 d5 2b 4c ad 52 ad 52 ab 4b 32 d5 34 d5 2b 2c
+*/
+/* check diff manchester:
+apparently:
+          FC CD 55 55 4A B4 D4 B2 AD 52 AB 54 CD 34 AB 54 CD 2C
+"1 111110 01 10 011010101010101010101010 0101010110100110101001011001010101101010100101010101101010100110011010011010010101011010101001100110100101100";
+          0  0  0 0 1 1 1 1 1 1 1 1 1 1  0 1 1 1 0 1 0 0 1 1 0 1 0 0 1 1 1 0 1 1 1 0 1 1 1 1 0 1 1 1 0 0 0 0 1 0 0 1 0 1 1 1 0 1 1 1 0 0 0 0 1 0 1 0 0
+
+*/
+//test const char PROGMEM packetOne[] = "111111111111110000000000000111111100000000111100001100111011001010101101010100101010101101010100110011010011010010101011010101001100110100101100";
+//const char PROGMEM packetOne[] = "111111001100110101010101010101010100101010110100110101001011001010101101010100101010101101010100110011010011010010101011010101001100110100101100";
+//const char PROGMEM packetTwo[] = "111111001011001100101011001100101010101101001011001011010101010101001010101011010101010100110100110011001010101101010101001100101010101010101100";
+//const char PROGMEM packetFour[] = "111111001100110010101010101011010010101010110100110101001011001101010010101011010101010101010100110011001100101101010101010011001100110101001100";
+//const char PROGMEM packetThree[] = "111111001011001010110011010010101100110101001011001010110100101101001101010100101010101011010100110011001011010010101011010101001101010010101100";
+// mine:
+// 07698722
+const char PROGMEM packetOne[] = "111111001011001101001101001010110010101010110011010100101010110101001010101011010101010010101011001100101100101011001011010011010010110010101100";
+const char PROGMEM packetTwo[] = "111111001101010101010101010010110010110101001100101011010101001010110010101011010101010101001011001100110010101011001011010011001100110101001100";
+const char PROGMEM packetThree[] = "111111001010101011010010110101010010101101001100101011010101001010101101010100101010101101001011001100101101010100110100110101010010101100101100";
+const char PROGMEM packetFour[] = "111111001100110010110100101011001011001010110011010101010101001010110101010100101010101010101011001100110011010100110100101100110101001100101100";
 
 // Allocate the memory
-char currentPacket[] = "111111001100110010101010101011010010101010110100110101001011001101010010101011010101010101010100110011001100101101010101010011001100110101001100";
+// volatile
+char currentPacket[] = "111111001011001101001101001010110010101010110011010100101010110101001010101011010101010010101011001100101100101011001011010011010010110010101100";
 
 volatile unsigned int currentPos;
 volatile bool transmitting = false;
 volatile int wakeupCounter = 0;
 
-// Interrupt for 10khz for an 8MHz clock
+// static code to execute earlier that setup/loop
+class initcode {
+public:
+  initcode();
+};
+
+initcode::initcode()
+{
+  pinMode(PIN_EN, OUTPUT);
+  pinMode(PIN_ASK, OUTPUT);
+  ENLOW;
+  ASKHIGH;
+}
+initcode soft;
+
+// 10khz Interrupt for an 8MHz clock
 void setupInterrupt8()
 {
   noInterrupts();
@@ -50,10 +145,15 @@ void setupInterrupt8()
   TCCR1B |= (1 << CS11);
   // Output Compare Match A Interrupt Enable
   TIMSK1 |= (1 << OCIE1A);
+
+  // button interrupt
+  PCMSK0 |= (1 << INTERRUPT_PIN);
+  GIMSK |= (1 << PCIE0 );
+  pinMode(PIN_BUTTON, INPUT_PULLUP);
   interrupts();
 }
 
-// Interrupt for 10khz for a 16MHz clock
+// 10khz Interrupt for a 16MHz clock
 void setupInterrupt16()
 {
   noInterrupts();
@@ -95,30 +195,47 @@ void setup()
 #else
 #error CPU is not set to 16MHz or 8MHz!
 #endif
-  wakeupCounter = 254; // This will force a transmit when powered on, helps with debug
+  wakeupCounter = WAKEUPCOUNT+1; // This will force a transmit soonish after powered on, helps with debug
 }
 
 ISR(TIMER1_COMPA_vect)
 {
   if (transmitting)
   {
+    if (currentPos >= PACKETSIZE)
+    {
+      disableTX();
+      return;
+    }
+
     if (currentPacket[currentPos] == '1')
       FSKHIGH;
     else
       FSKLOW;
-
-    if (++currentPos > PACKETSIZE)
-    {
-      transmitting = false;
-      disableTX();
-    }
+    currentPos++;
   }
 }
 
+#define ENABLE_WDT // continually resets? if disabled!
+#ifdef ENABLE_WDT
+// watchdog timer is setup by sleepytime(). should be every 8s.
 ISR(WDT_vect)
 {
   wakeupCounter++;
   wdt_disable(); // disable watchdog
+}
+#endif
+
+ISR(PCINT0_vect)
+{
+  if( digitalRead(PIN_BUTTON) == LOW ) {
+    // button press. force wakeup
+    wakeupCounter = WAKEUPCOUNT + 1;
+    //digitalWrite(LED_PIN, HIGH);
+  } else {
+    // button release
+    //digitalWrite(LED_PIN, LOW);
+  }
 }
 
 void sleepyTime()
@@ -134,6 +251,7 @@ void sleepyTime()
   power_timer2_disable();
   power_twi_disable();
 
+#ifdef ENABLE_WDT
   // clear various "reset" flags
   MCUSR = 0;
 
@@ -143,49 +261,52 @@ void sleepyTime()
   // set interrupt mode and an interval
   WDTCSR = bit(WDIE) | bit(WDP3) | bit(WDP0); // set WDIE, and 8 seconds delay
   wdt_reset();                                // pat the dog
+#endif
 
   set_sleep_mode(SLEEP_MODE_PWR_DOWN);
   noInterrupts(); // timed sequence follows
   sleep_enable();
   interrupts(); // guarantees next instruction executed
   sleep_cpu();
+
+  //sleep_disable();
 }
 
 void sendPacket(const char *thePacket)
 {
+  transmitting = false; // just in case...
   memcpy_P(currentPacket, thePacket, PACKETSIZE);
-
+  //currentPacket = thePacket;
   currentPos = 0;
 
   enableTX();
-  transmitting = true;
 }
 
 void loop()
 {
   if (wakeupCounter > WAKEUPCOUNT)
   {
+    sendPacket(packetOne);
+    //while (transmitting)
+    //  __asm__("nop\n\t"); // why not empty {}
+    delay(PACKET_DELAY); // presumably delay will mess with ISR/tx??
+
+    //sendPacket(packetTwo);
+    //while (transmitting)
+    //  __asm__("nop\n\t");
+    delay(PACKET_DELAY);
+
+    //sendPacket(packetThree);
+    //while (transmitting)
+    //  __asm__("nop\n\t");
+    delay(PACKET_DELAY);
+
+    //sendPacket(packetFour);
+    //while (transmitting)
+    //  __asm__("nop\n\t");
+    delay(PACKET_DELAY);
+
     wakeupCounter = 0;
-
-    sendPacket((char *)packetOne);
-    while (transmitting)
-      __asm__("nop\n\t");
-    delay(PACKET_DELAY);
-
-    sendPacket(packetTwo);
-    while (transmitting)
-      __asm__("nop\n\t");
-    delay(PACKET_DELAY);
-
-    sendPacket(packetThree);
-    while (transmitting)
-      __asm__("nop\n\t");
-    delay(PACKET_DELAY);
-
-    sendPacket(packetFour);
-    while (transmitting)
-      __asm__("nop\n\t");
-    delay(PACKET_DELAY);
   }
 
   sleepyTime();
@@ -193,15 +314,23 @@ void loop()
 
 void enableTX()
 {
-  FSKLOW;
-  digitalWrite(PIN_ASK, HIGH);
-  digitalWrite(PIN_EN, HIGH);
-  delay(1); //1mS to wake up
+  FSKLOW;  // not required? or should be high!
+  //ASKLOW;
+  //delay(1);
+  ASKHIGH;
+  ENHIGH;
+  //digitalWrite(PIN_ASK, HIGH);
+  //digitalWrite(PIN_EN, HIGH);
+  delayMicroseconds(300); // 200uS //1mS to wake up
+  transmitting = true;
 }
 
 void disableTX()
 {
-  FSKLOW;
-  digitalWrite(PIN_ASK, LOW);
-  digitalWrite(PIN_EN, LOW);
+  ENLOW;
+  FSKLOW;  // not required? Allow OOK decoding
+  //ASKLOW;
+  //digitalWrite(PIN_ASK, LOW);
+  //digitalWrite(PIN_EN, LOW);
+  transmitting = false;
 }

--- a/Code/src/main.cpp
+++ b/Code/src/main.cpp
@@ -20,7 +20,7 @@
 // Tie ASK and FSK signals together to drive high stronger/faster?
 // cut ASK link between attiny and MICRF112.
 // bodge ASK to EN on MICRF112. and ASK/FSK together on the attiny
-#define FSK_MOD
+//#define FSK_MOD
 
 #ifdef FSK_MOD
 // ASK is tied high already
@@ -48,6 +48,7 @@
 #define PACKET_DELAY 65 // Milliseconds period for packet tx
 #ifdef BACKOFF
 #define LIMIT_START   1 // (retx intervals 14s, 28s, 56s, ...)
+#define MAX_LIMIT     160 // 80 max limit = 10mins
 #else
 #define LIMIT_START   8 // ~60s = 8 (7s) wakeups before transmit
 #endif
@@ -267,7 +268,7 @@ void sendPacket(const char *thePacket)
 {
   transmitting = false; // just in case...
   memcpy_P(currentPacket, thePacket, PACKETSIZE);
-  //memcpy((void*) currentPacket, thePacket, PACKETSIZE+1);
+  //currentPacket = (char *) thepacket; OR memcpy((void*) currentPacket, thePacket, PACKETSIZE+1);
   currentPos = 0;
 
   enableTX();
@@ -293,6 +294,9 @@ void loop()
     // double the wakeuplimit each time to back-off and save battery
 #ifdef BACKOFF
     wakeuplimit *= 2;
+#ifdef MAX_LIMIT
+    wakeuplimit = min(wakeuplimit, MAX_LIMIT);
+#endif
 #endif
   }
 

--- a/Code/src/main.cpp
+++ b/Code/src/main.cpp
@@ -24,24 +24,6 @@ BACKOFF will double the retransmit period each time until MAX_LIMIT.
 #define ENHIGH (bitSet(PORTA, 0))
 #define ENLOW (bitClear(PORTA, 0))
 
-// * unecessary hardware modification *
-// Tie ASK and FSK signals together to drive high stronger/faster?
-// cut ASK link between attiny and MICRF112.
-// bodge ASK to EN on MICRF112. and ASK/FSK together on the attiny.
-//#define FSK_MOD
-
-#ifdef FSK_MOD
-// ASK is tied high already
-#define ASKHIGH {}
-#define ASKLOW {}
-
-// drive PA1 & PA2 together
-#define FSKLOW (PORTA &= ~(0x6))
-#define FSKHIGH (PORTA |= 0x6)
-#define FSKTOGGLE (PORTA = PORTA ^ (0x6))
-
-#else
-
 #define ASKHIGH (bitSet(PORTA, 2))
 #define ASKLOW (bitClear(PORTA, 2))
 
@@ -49,7 +31,6 @@ BACKOFF will double the retransmit period each time until MAX_LIMIT.
 #define FSKLOW (bitClear(PORTA, 1))
 #define FSKTOGGLE (PORTA = PORTA ^ _BV(1))
 
-#endif
 
 #define PACKET_DELAY   40 // Milliseconds inter-packet period
 #ifdef BACKOFF


### PR DESCRIPTION

Added support/interrupt for the button - initiates an immediate transmission.
Watchdog can be disabled to only transmit on button press
Simplified watchdog handling
Moved more code to setup(), reduced the code executed in interrupts/loop().
Implemented hex-byte storage of the packets for space savings.
Removed need for memcpy_P()
Tightened warm-up timing in enableTx()
Powered off ISR timer1 between packets.
Fixed tx of the last bit of each packet.
Implemented a back-off algorithm to double the period between transmissions to a maximum. Would be useful if reception wasn't reliable... maybe?

Note. has my Toyota's tpms data here, follow the comments to capture/replace with your own using rtl_433 and a rtl-sdr dongle.


Image usage without #def BACKOFF:
```
RAM:   [==        ]  17.4% (used 89 bytes from 512 bytes)
Flash: [==        ]  17.6% (used 1440 bytes from 8192 bytes)
```
